### PR TITLE
Avoid allocating in LineSpan.GetHashCode

### DIFF
--- a/src/Guides/DocumentAnalyzer.cs
+++ b/src/Guides/DocumentAnalyzer.cs
@@ -175,7 +175,7 @@ namespace IndentGuide {
         }
 
         public override int GetHashCode() {
-            return new { FirstLine, LastLine, Indent, Type }.GetHashCode();
+            return new { FirstLine, LastLine, Indent, Type = (int)Type }.GetHashCode();
         }
     }
 


### PR DESCRIPTION
In .NET Framework, Enum.GetHashCode boxes the underlying enum, causing an allocation. This was caught by our telemetry as a high cause of GC pressure during our automatic trace collection.

See internal bug #1800481 for context.