### PR TITLE
Avoid boxing enumerator

### DIFF
--- a/src/Guides/DocumentAnalyzer.cs
+++ b/src/Guides/DocumentAnalyzer.cs
@@ -84,7 +84,7 @@ namespace IndentGuide {
             var result = new HashSet<LineSpan>();
             var queue = new Queue<LineSpan>();
             queue.Enqueue(line);
-            while (queue.Any()) {
+            while (queue.Count > 0) {
                 var ls = queue.Dequeue();
                 if (result.Add(ls) && ls._LinkedLines != null) {
                     foreach (var ls2 in ls._LinkedLines) {


### PR DESCRIPTION
Calling Any() on Queue<T> boxes its underlying enumerator causing an allocation.  This was caught by our telemetry as a high cause of GC pressure during our automatic trace collection.